### PR TITLE
FOLIO-3678 Enable GitHub Workflows api-lint and api-schema-lint and api-doc

### DIFF
--- a/.github/workflows/api-doc.yml
+++ b/.github/workflows/api-doc.yml
@@ -33,6 +33,7 @@ on:
     paths:
       - 'src/main/resources/swagger.api/**'
     tags: '[vV][0-9]+.[0-9]+.[0-9]+*'
+  workflow_dispatch:
 
 jobs:
   api-doc:

--- a/.github/workflows/api-lint.yml
+++ b/.github/workflows/api-lint.yml
@@ -33,6 +33,7 @@ on:
   pull_request:
     paths:
       - 'src/main/resources/swagger.api/**'
+  workflow_dispatch:
 
 jobs:
   api-lint:

--- a/.github/workflows/api-schema-lint.yml
+++ b/.github/workflows/api-schema-lint.yml
@@ -23,6 +23,7 @@ on:
   pull_request:
     paths:
       - 'src/main/resources/swagger.api/**'
+  workflow_dispatch:
 
 jobs:
   api-schema-lint:

--- a/src/main/resources/swagger.api/circulation-bff-requests.yaml
+++ b/src/main/resources/swagger.api/circulation-bff-requests.yaml
@@ -97,3 +97,4 @@ components:
             total_records: 1
           schema:
             $ref: "#/components/schemas/errorResponse"
+


### PR DESCRIPTION
Workflows need an initial run. Because they only act on specific paths, it needed a subsequent change to a relevant file.

This PR does that.

Also please keep Workflow files synchronised with [https://github.com/folio-org/.github/workflow-templates](https://github.com/folio-org/.github/tree/master/workflow-templates) 