### PR TITLE
MCBFF-19 Make 'pickupServicePointId' field non-required for POST '/circulation-bff/requests' endpoint

### DIFF
--- a/src/main/resources/swagger.api/schemas/dto/request/BffRequest.yaml
+++ b/src/main/resources/swagger.api/schemas/dto/request/BffRequest.yaml
@@ -207,4 +207,3 @@ BffRequest:
     - "fulfillmentPreference"
     - "instanceId"
     - "requestLevel"
-    - "pickupServicePointId"


### PR DESCRIPTION
## Purpose
Property pickupServicePointId is required in request to endpoint POST /circulation-bff/requests, which makes it impossible to create a request with fulfillment preference set to Delivery. Makes this property non-required

Resolves: [MCBFF-19](https://folio-org.atlassian.net/browse/MCBFF-19)