### PR TITLE
MCBFF-40 Add missing required interfaces

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -289,6 +289,14 @@
     {
       "id":  "circulation",
       "version": "14.4"
+    },
+    {
+      "id":  "circulation-settings",
+      "version": "1.0"
+    },
+    {
+      "id":  "instance-storage",
+      "version": "11.0"
     }
   ],
   "optional": [
@@ -306,6 +314,18 @@
     },
     {
       "id": "ecs-request-external",
+      "version": "1.0"
+    },
+    {
+      "id": "requests-mediated-actions",
+      "version": "1.1"
+    },
+    {
+      "id": "ecs-tlr-allowed-service-points",
+      "version": "1.0"
+    },
+    {
+      "id": "ecs-tlr",
       "version": "1.0"
     }
   ],


### PR DESCRIPTION
## Purpose
MCBFF-40 

## Approach
Add missing required interfaces.

Some required interfaces are not specified in Module Descriptor. This leads to excessive egress request routing though Kong, instead of direct calls to other module sidecars.