### PR TITLE
MCBFF-87  Add Location and  Loan type fields for circulation-bff/requests/search-instances endpoint

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -80,7 +80,7 @@
     },
     {
       "id": "circulation-bff-requests",
-      "version": "1.1",
+      "version": "1.2",
       "handlers": [
         {
           "methods": [
@@ -387,6 +387,8 @@
         "inventory-storage.material-types.collection.get",
         "inventory-storage.instances.item.get",
         "inventory-storage.instances.collection.get",
+        "inventory-storage.loan-types.collection.get",
+        "inventory-storage.loan-types.item.get",
         "consortium-search.items.collection.get",
         "consortium-search.items.item.get",
         "tlr.ecs-request-external.post",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -327,6 +327,10 @@
       "version": "2.2"
     },
     {
+      "id":  "loan-types",
+      "version": "2.3"
+    },
+    {
       "id":  "circulation",
       "version": "14.4"
     },

--- a/src/main/java/org/folio/circulationbff/client/feign/LoanTypeClient.java
+++ b/src/main/java/org/folio/circulationbff/client/feign/LoanTypeClient.java
@@ -1,0 +1,16 @@
+package org.folio.circulationbff.client.feign;
+
+import org.folio.circulationbff.domain.dto.LoanType;
+import org.folio.circulationbff.domain.dto.LoanTypes;
+import org.folio.spring.config.FeignClientConfiguration;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "loan-types", url = "loan-types",
+  configuration = FeignClientConfiguration.class)
+public interface LoanTypeClient extends GetByQueryClient<LoanTypes> {
+
+  @GetMapping("/{id}")
+  LoanType findLoanType(@PathVariable String id);
+}

--- a/src/main/java/org/folio/circulationbff/controller/CirculationBffController.java
+++ b/src/main/java/org/folio/circulationbff/controller/CirculationBffController.java
@@ -28,6 +28,7 @@ import org.folio.circulationbff.service.CheckInService;
 import org.folio.circulationbff.service.CheckOutService;
 import org.folio.circulationbff.service.CirculationBffService;
 import org.folio.circulationbff.service.EcsRequestExternalService;
+import org.folio.circulationbff.service.InventoryService;
 import org.folio.circulationbff.service.MediatedRequestsService;
 import org.folio.circulationbff.service.SearchService;
 import org.folio.circulationbff.service.UserService;
@@ -46,6 +47,7 @@ public class CirculationBffController implements CirculationBffApi {
 
   private final CirculationBffService circulationBffService;
   private final SearchService searchService;
+  private final InventoryService inventoryService;
   private final MediatedRequestsService mediatedRequestsService;
   private final UserService userService;
   private final EcsRequestExternalService ecsRequestExternalService;
@@ -114,9 +116,16 @@ public class CirculationBffController implements CirculationBffApi {
     // frontend expects either a single instance, or an empty JSON
     BffSearchInstance response = instances.stream()
       .findFirst()
+//      .map(searchInstance -> addPropertiesForItems(searchInstance))
       .orElseGet(EmptyBffSearchInstance::new);
 
     return ResponseEntity.ok(response);
+  }
+
+  private BffSearchInstance addPropertiesForItems(BffSearchInstance bffSearchInstance) {
+    bffSearchInstance.getItems().forEach(item -> item.getEffectiveLocation());
+
+    return bffSearchInstance;
   }
 
   @Override

--- a/src/main/java/org/folio/circulationbff/controller/CirculationBffController.java
+++ b/src/main/java/org/folio/circulationbff/controller/CirculationBffController.java
@@ -28,7 +28,6 @@ import org.folio.circulationbff.service.CheckInService;
 import org.folio.circulationbff.service.CheckOutService;
 import org.folio.circulationbff.service.CirculationBffService;
 import org.folio.circulationbff.service.EcsRequestExternalService;
-import org.folio.circulationbff.service.InventoryService;
 import org.folio.circulationbff.service.MediatedRequestsService;
 import org.folio.circulationbff.service.SearchService;
 import org.folio.circulationbff.service.UserService;
@@ -47,7 +46,6 @@ public class CirculationBffController implements CirculationBffApi {
 
   private final CirculationBffService circulationBffService;
   private final SearchService searchService;
-  private final InventoryService inventoryService;
   private final MediatedRequestsService mediatedRequestsService;
   private final UserService userService;
   private final EcsRequestExternalService ecsRequestExternalService;
@@ -116,16 +114,9 @@ public class CirculationBffController implements CirculationBffApi {
     // frontend expects either a single instance, or an empty JSON
     BffSearchInstance response = instances.stream()
       .findFirst()
-//      .map(searchInstance -> addPropertiesForItems(searchInstance))
       .orElseGet(EmptyBffSearchInstance::new);
 
     return ResponseEntity.ok(response);
-  }
-
-  private BffSearchInstance addPropertiesForItems(BffSearchInstance bffSearchInstance) {
-    bffSearchInstance.getItems().forEach(item -> item.getEffectiveLocation());
-
-    return bffSearchInstance;
   }
 
   @Override

--- a/src/main/java/org/folio/circulationbff/service/impl/SearchServiceImpl.java
+++ b/src/main/java/org/folio/circulationbff/service/impl/SearchServiceImpl.java
@@ -260,7 +260,7 @@ public class SearchServiceImpl implements SearchService {
       .filter(Objects::nonNull)
       .collect(Collectors.toSet());
 
-    log.info("fetchLoanTypes: fetching {} loan types", ids.size());
+    log.info("fetchLoanTypes:: fetching {} loan types", ids.size());
 
     return fetchingService.fetch(loanTypeClient, ids, LoanTypes::getLoantypes, LoanType::getId);
   }

--- a/src/main/java/org/folio/circulationbff/service/impl/SearchServiceImpl.java
+++ b/src/main/java/org/folio/circulationbff/service/impl/SearchServiceImpl.java
@@ -8,17 +8,20 @@ import static java.util.stream.Collectors.toSet;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.circulationbff.client.feign.HoldingsStorageClient;
 import org.folio.circulationbff.client.feign.InstanceStorageClient;
 import org.folio.circulationbff.client.feign.ItemStorageClient;
+import org.folio.circulationbff.client.feign.LoanTypeClient;
 import org.folio.circulationbff.client.feign.LocationClient;
 import org.folio.circulationbff.client.feign.MaterialTypeClient;
 import org.folio.circulationbff.client.feign.SearchClient;
@@ -26,10 +29,12 @@ import org.folio.circulationbff.client.feign.ServicePointClient;
 import org.folio.circulationbff.domain.dto.BffSearchInstance;
 import org.folio.circulationbff.domain.dto.BffSearchItem;
 import org.folio.circulationbff.domain.dto.BffSearchItemCallNumberComponents;
+import org.folio.circulationbff.domain.dto.BffSearchItemEffectiveLocation;
 import org.folio.circulationbff.domain.dto.BffSearchItemInTransitDestinationServicePoint;
-import org.folio.circulationbff.domain.dto.BffSearchItemLocation;
 import org.folio.circulationbff.domain.dto.BffSearchItemMaterialType;
+import org.folio.circulationbff.domain.dto.BffSearchItemPermanentLoanType;
 import org.folio.circulationbff.domain.dto.BffSearchItemStatus;
+import org.folio.circulationbff.domain.dto.BffSearchItemTemporaryLoanType;
 import org.folio.circulationbff.domain.dto.ConsortiumItem;
 import org.folio.circulationbff.domain.dto.Contributor;
 import org.folio.circulationbff.domain.dto.HoldingsRecord;
@@ -39,6 +44,8 @@ import org.folio.circulationbff.domain.dto.Instances;
 import org.folio.circulationbff.domain.dto.Item;
 import org.folio.circulationbff.domain.dto.ItemEffectiveCallNumberComponents;
 import org.folio.circulationbff.domain.dto.Items;
+import org.folio.circulationbff.domain.dto.LoanType;
+import org.folio.circulationbff.domain.dto.LoanTypes;
 import org.folio.circulationbff.domain.dto.Location;
 import org.folio.circulationbff.domain.dto.Locations;
 import org.folio.circulationbff.domain.dto.MaterialType;
@@ -67,6 +74,7 @@ public class SearchServiceImpl implements SearchService {
   private final HoldingsStorageClient holdingsStorageClient;
   private final LocationClient locationClient;
   private final MaterialTypeClient materialTypeClient;
+  private final LoanTypeClient loanTypeClient;
   private final ServicePointClient servicePointClient;
   private final SearchClient searchClient;
   private final InstanceStorageClient instanceStorageClient;
@@ -200,6 +208,7 @@ public class SearchServiceImpl implements SearchService {
     Map<String, MaterialType> materialTypesById = fetchMaterialTypes(items);
     Map<String, String> itemIdToTenantId = searchItems.stream()
       .collect(toMap(SearchItem::getId, SearchItem::getTenantId));
+    Map<String, LoanType> loanTypeIdToLoanType = fetchLoanTypes(items);
 
     return items.stream()
       .map(item -> new ItemContext(item,
@@ -207,7 +216,9 @@ public class SearchServiceImpl implements SearchService {
         holdingsRecordsById.get(item.getHoldingsRecordId()),
         locationsById.get(item.getEffectiveLocationId()),
         materialTypesById.get(item.getMaterialTypeId()),
-        servicePointsById.get(item.getInTransitDestinationServicePointId())))
+        servicePointsById.get(item.getInTransitDestinationServicePointId()),
+        loanTypeIdToLoanType.get(item.getPermanentLoanTypeId()),
+        loanTypeIdToLoanType.get(item.getTemporaryLoanTypeId())))
       .toList();
   }
 
@@ -241,6 +252,17 @@ public class SearchServiceImpl implements SearchService {
     log.info("fetchMaterialTypes: fetching {} material types", ids::size);
     return fetchingService.fetch(materialTypeClient, ids, MaterialTypes::getMtypes,
       MaterialType::getId);
+  }
+
+  private Map<String, LoanType> fetchLoanTypes(Collection<Item> items) {
+    Set<String> ids = items.stream()
+      .flatMap(item -> Stream.of(item.getPermanentLoanTypeId(), item.getTemporaryLoanTypeId()))
+      .filter(Objects::nonNull)
+      .collect(Collectors.toSet());
+
+    log.info("fetchLoanTypes: fetching {} loan types", ids.size());
+
+    return fetchingService.fetch(loanTypeClient, ids, LoanTypes::getLoantypes, LoanType::getId);
   }
 
   private Collection<BffSearchInstance> buildBffSearchInstances(
@@ -294,6 +316,20 @@ public class SearchServiceImpl implements SearchService {
       .volume(item.getVolume())
       .inTransitDestinationServicePointId(toUUID(item.getInTransitDestinationServicePointId()));
 
+    var permanentLoanTypeId = item.getPermanentLoanTypeId();
+    if (permanentLoanTypeId != null) {
+      bffSearchItem.permanentLoanType(new BffSearchItemPermanentLoanType()
+        .id(item.getPermanentLoanTypeId())
+        .name(itemContext.permanentLoanType.getName()));
+    }
+
+    var temporaryLoanTypeId = item.getTemporaryLoanTypeId();
+    if (temporaryLoanTypeId != null) {
+      bffSearchItem.temporaryLoanType(new BffSearchItemTemporaryLoanType()
+        .id(item.getTemporaryLoanTypeId())
+        .name(itemContext.temporaryLoanType.getName()));
+    }
+
     Optional.ofNullable(searchInstance.getContributors())
       .map(contributors -> contributors.stream()
         .map(Contributor::getName)
@@ -319,8 +355,8 @@ public class SearchServiceImpl implements SearchService {
       .ifPresent(bffSearchItem::setInTransitDestinationServicePoint);
 
     Optional.ofNullable(itemContext.location())
-      .map(loc -> new BffSearchItemLocation().name(loc.getName()))
-      .ifPresent(bffSearchItem::setLocation);
+      .map(loc -> new BffSearchItemEffectiveLocation().name(loc.getName()))
+      .ifPresent(bffSearchItem::setEffectiveLocation);
 
     Optional.ofNullable(itemContext.materialType())
       .map(mt -> new BffSearchItemMaterialType().name(mt.getName()))
@@ -355,6 +391,7 @@ public class SearchServiceImpl implements SearchService {
   }
 
   private record ItemContext(Item item, String tenantId, HoldingsRecord holdingsRecord,
-    Location location, MaterialType materialType, ServicePoint servicePoint) { }
+    Location location, MaterialType materialType, ServicePoint servicePoint,
+    LoanType permanentLoanType, LoanType temporaryLoanType) { }
 
 }

--- a/src/main/java/org/folio/circulationbff/service/impl/SearchServiceImpl.java
+++ b/src/main/java/org/folio/circulationbff/service/impl/SearchServiceImpl.java
@@ -318,16 +318,28 @@ public class SearchServiceImpl implements SearchService {
 
     var permanentLoanTypeId = item.getPermanentLoanTypeId();
     if (permanentLoanTypeId != null) {
-      bffSearchItem.permanentLoanType(new BffSearchItemPermanentLoanType()
-        .id(item.getPermanentLoanTypeId())
-        .name(itemContext.permanentLoanType.getName()));
+      var permanentLoanType = itemContext.permanentLoanType();
+      if (permanentLoanType != null) {
+        bffSearchItem.permanentLoanType(new BffSearchItemPermanentLoanType()
+          .id(permanentLoanTypeId)
+          .name(permanentLoanType.getName()));
+      } else {
+        log.info("buildBffSearchItem:: permanent loan type is null for item with permanentLoanTypeId: {}",
+          permanentLoanTypeId);
+      }
     }
 
     var temporaryLoanTypeId = item.getTemporaryLoanTypeId();
     if (temporaryLoanTypeId != null) {
-      bffSearchItem.temporaryLoanType(new BffSearchItemTemporaryLoanType()
-        .id(item.getTemporaryLoanTypeId())
-        .name(itemContext.temporaryLoanType.getName()));
+      var temporaryLoanType = itemContext.temporaryLoanType();
+      if (temporaryLoanType != null) {
+        bffSearchItem.temporaryLoanType(new BffSearchItemTemporaryLoanType()
+          .id(temporaryLoanTypeId)
+          .name(temporaryLoanType.getName()));
+      } else {
+        log.info("buildBffSearchItem:: is null for item with temporaryLoanTypeId: {}",
+          temporaryLoanTypeId);
+      }
     }
 
     Optional.ofNullable(searchInstance.getContributors())

--- a/src/main/resources/permissions/mod-circulation-bff.csv
+++ b/src/main/resources/permissions/mod-circulation-bff.csv
@@ -18,6 +18,8 @@ inventory-storage.location-units.campuses.item.get
 inventory-storage.location-units.campuses.collection.get
 inventory-storage.location-units.institutions.item.get
 inventory-storage.location-units.institutions.collection.get
+inventory-storage.loan-types.collection.get
+inventory-storage.loan-types.item.get
 user-tenants.collection.get
 consortium-search.items.collection.get
 consortium-search.items.item.get

--- a/src/main/resources/swagger.api/circulation-bff.yaml
+++ b/src/main/resources/swagger.api/circulation-bff.yaml
@@ -48,6 +48,8 @@ components:
       $ref: 'schemas/dto/inventory/institutions.json'
     service-points:
       $ref: 'schemas/dto/inventory/servicePoints.json'
+    loan-types:
+      $ref: 'schemas/dto/inventory/loanTypes.json'
     material-types:
       $ref: 'schemas/dto/inventory/materialTypes.json'
     search-instances:

--- a/src/main/resources/swagger.api/schemas/dto/inventory/item.json
+++ b/src/main/resources/swagger.api/schemas/dto/inventory/item.json
@@ -308,6 +308,34 @@
       "type": "string",
       "description": "Temporary loan type, is the temporary loan type for a given item."
     },
+    "permanentLoanType": {
+      "description": "Permanent loan type, is the default loan type for a given item. Loan types are tenant-defined in a reference table in Settings, Inventory, Item, Loan type (e.g. Can circulate, Course reserves, Reading room, Selected)",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Permanent loan type Id, refers to a loan type reference record",
+          "type": "string"
+        },
+        "name": {
+          "description": "Permanent loan type name",
+          "type": "string"
+        }
+      }
+    },
+    "temporaryLoanType": {
+      "description": "Temporary loan type, is the temporary loan type for a given item. Loan types are tenant-defined in a reference table in Settings, Inventory, Item, Loan type (e.g. Can circulate, Course reserves, Reading room, Selected)",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Temporary loan type Id, refers to a loan type reference record",
+          "type": "string"
+        },
+        "name": {
+          "description": "Temporary loan type name",
+          "type": "string"
+        }
+      }
+    },
     "permanentLocationId": {
       "type": "string",
       "description": "Permanent item location is the default location, shelving location, or holding which is a physical place where items are stored, or an Online location."

--- a/src/main/resources/swagger.api/schemas/dto/inventory/loanType.json
+++ b/src/main/resources/swagger.api/schemas/dto/inventory/loanType.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "A loan type",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "name": {
+      "description": "label for the loan type",
+      "type": "string"
+    },
+    "source": {
+      "description": "Origin of the loan type record, e.g. 'System', 'User', 'Consortium' etc.",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object",
+      "$ref": "../common/metadata.yaml",
+      "readonly": true
+    }
+  }
+}

--- a/src/main/resources/swagger.api/schemas/dto/inventory/loanTypes.json
+++ b/src/main/resources/swagger.api/schemas/dto/inventory/loanTypes.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "A collection of loan types",
+  "type": "object",
+  "properties": {
+    "loantypes": {
+      "description": "List of loan types",
+      "id": "loantype",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "loanType.json"
+      }
+    },
+    "totalRecords": {
+      "description": "Estimated or exact total number of records",
+      "type": "integer"
+    }
+  }
+}

--- a/src/main/resources/swagger.api/schemas/dto/search/bffSearchItem.yaml
+++ b/src/main/resources/swagger.api/schemas/dto/search/bffSearchItem.yaml
@@ -49,12 +49,35 @@ properties:
   barcode:
     description: "The barcode of the item"
     type: string
-  location:
+  effectiveLocation:
     description: "The effective location of the item"
     type: object
     properties:
+      id:
+        description: "Effective location ID"
+        type: string
       name:
         description: "The name of the location"
+        type: string
+  permanentLoanType:
+    description: "The permanent loan type, is the default loan type for a given item. Loan types are tenant-defined"
+    type: object
+    properties:
+      id:
+        description: "Permanent loan type ID, refers to a loan type reference record"
+        type: string
+      name:
+        description: "The name of permanent loan type"
+        type: string
+  temporaryLoanType:
+    description: "Temporary loan type, is the temporary loan type for a given item"
+    type: object
+    properties:
+      id:
+        description: "Temporary loan type Id, refers to a loan type reference record"
+        type: string
+      name:
+        description: "The name of temporary loan type"
         type: string
   status:
     description: "Overall status of the item"


### PR DESCRIPTION
## Purpose
Description
Overview: "Location" and  "Loan type" fields are empty on "Select item" modal during request creation

Steps to reproduce:
Login into eureka snapshot (ecs or non-ecs)
Go to “Requests” app
Click on “Actions” > “+ New”
Check  “Create title level request” checkbox
Scan any Instance with Item
Uncheck “Create title level request” checkbox

Expected result: "Location" and  "Loan type" fields contains data
Actual result: "Location" and  "Loan type" fields are empty 
Additional info: reproducible on both ECS and NON-ECS Eureka snapshot environments

Resolves: [MCBFF-87](https://folio-org.atlassian.net/browse/MCBFF-87)


