### PR TITLE
MCBFF-158 Close secure loan after claimed returned item checked in

### DIFF
--- a/src/main/java/org/folio/circulationbff/service/impl/CheckInServiceImpl.java
+++ b/src/main/java/org/folio/circulationbff/service/impl/CheckInServiceImpl.java
@@ -2,6 +2,7 @@ package org.folio.circulationbff.service.impl;
 
 import static java.util.stream.Collectors.joining;
 import static org.folio.circulationbff.domain.dto.CirculationItemStatus.NameEnum.CHECKED_OUT;
+import static org.folio.circulationbff.domain.dto.CirculationItemStatus.NameEnum.CLAIMED_RETURNED;
 
 import java.util.List;
 import java.util.Optional;
@@ -133,7 +134,7 @@ public class CheckInServiceImpl implements CheckInService {
     log.info("loanExistsInSecureTenant:: checking if open loan for item {} exists in secure tenant",
       circItem::getId);
     boolean result = tenantService.getSecureTenantId()
-      .map(secureTenantId -> circulationItemIsInStatus(circItem, CHECKED_OUT) &&
+      .map(secureTenantId -> circulationItemIsInStatus(circItem, CHECKED_OUT, CLAIMED_RETURNED) &&
         openLoanExists(circItem.getId().toString(), secureTenantId))
       .orElse(false);
 
@@ -514,15 +515,21 @@ public class CheckInServiceImpl implements CheckInService {
   }
 
   private static boolean circulationItemIsInStatus(CirculationItem circulationItem,
-    CirculationItemStatus.NameEnum expectedStatus) {
+    CirculationItemStatus.NameEnum... expectedStatuses) {
 
-    log.info("circulationItemIsInStatus:: checking if circulation item {} is in status {}",
-      circulationItem::getId, expectedStatus::getValue);
+    log.info("circulationItemIsInStatus:: checking if circulation item {} is in one of statuses {}",
+      circulationItem != null ? circulationItem::getId : () -> null,
+      () -> expectedStatuses == null ? null : List.of(expectedStatuses));
 
-    boolean result = Optional.of(circulationItem)
+    if (expectedStatuses == null || expectedStatuses.length == 0) {
+      log.info("circulationItemIsInStatus:: no expected statuses provided");
+      return false;
+    }
+
+    boolean result = Optional.ofNullable(circulationItem)
       .map(CirculationItem::getStatus)
       .map(CirculationItemStatus::getName)
-      .map(actualStatus -> expectedStatus == actualStatus)
+      .map(actualStatus -> List.of(expectedStatuses).contains(actualStatus))
       .orElse(false);
 
     log.info("circulationItemIsInStatus:: result: {}", result);

--- a/src/test/java/org/folio/circulationbff/api/CheckInApiTest.java
+++ b/src/test/java/org/folio/circulationbff/api/CheckInApiTest.java
@@ -51,6 +51,7 @@ import org.folio.circulationbff.domain.dto.UserTenant;
 import org.folio.circulationbff.domain.dto.UserTenantCollection;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -668,9 +669,13 @@ class CheckInApiTest extends BaseIT {
       .withRequestBody(equalToJson(asJsonString(checkInRequest))));
   }
 
-  @Test
+  @ParameterizedTest
   @SneakyThrows
-  void centralTenantCheckInClosesOpenLoanInSecureTenant() {
+  @EnumSource(value = CirculationItemStatus.NameEnum.class,
+    names = {"CHECKED_OUT", "CLAIMED_RETURNED"})
+  void centralTenantCheckInClosesOpenLoanInSecureTenant(
+    CirculationItemStatus.NameEnum circulationItemStatus) {
+
     mockHelper.mockEcsTlrSettings(true);
     givenCurrentTenantIsConsortium();
     var itemId = randomId();
@@ -681,7 +686,7 @@ class CheckInApiTest extends BaseIT {
 
     CirculationItem circulationItem = new CirculationItem()
       .id(UUID.fromString(itemId))
-      .status(new CirculationItemStatus().name(CirculationItemStatus.NameEnum.CHECKED_OUT));
+      .status(new CirculationItemStatus().name(circulationItemStatus));
 
     wireMockServer.stubFor(WireMock.get(urlMatching(format(CIRCULATION_ITEM_URL, itemId)))
       .willReturn(jsonResponse(asJsonString(circulationItem), SC_OK)));

--- a/src/test/java/org/folio/circulationbff/service/CheckInServiceTest.java
+++ b/src/test/java/org/folio/circulationbff/service/CheckInServiceTest.java
@@ -5,6 +5,9 @@ import static org.folio.circulationbff.util.MockHelper.mockSystemUserService;
 import static org.folio.circulationbff.util.TestUtils.randomId;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -38,6 +41,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class CheckInServiceTest {
@@ -60,7 +64,7 @@ class CheckInServiceTest {
   private InventoryService inventoryService;
   @Mock
   private CirculationStorageService circulationStorageService;
-  @Mock
+  @Mock(strictness = Mock.Strictness.LENIENT)
   private SystemUserScopedExecutionService systemUserService;
   @Mock
   private UserService userService;
@@ -231,6 +235,21 @@ class CheckInServiceTest {
         .instanceId(instanceId));
 
     assertThat(checkInResponse, equalTo(expectedCheckInResponse));
+  }
+
+  @Test
+  void circulationItemIsInStatusHandlesNullParameters() {
+    Boolean resultWhenItemAndStatusesAreNull = ReflectionTestUtils.invokeMethod(
+      checkInService, "circulationItemIsInStatus", null, null);
+    Boolean resultWhenStatusesAreNull = ReflectionTestUtils.invokeMethod(
+      checkInService, "circulationItemIsInStatus", new CirculationItem(), null);
+    Boolean resultWhenStatusesAreEmpty = ReflectionTestUtils.invokeMethod(
+      checkInService, "circulationItemIsInStatus", new CirculationItem(),
+      new CirculationItemStatus.NameEnum[] {});
+
+    assertEquals(Boolean.FALSE, resultWhenItemAndStatusesAreNull);
+    assertEquals(Boolean.FALSE, resultWhenStatusesAreNull);
+    assertEquals(Boolean.FALSE, resultWhenStatusesAreEmpty);
   }
 
 }

--- a/src/test/java/org/folio/circulationbff/service/CheckInServiceTest.java
+++ b/src/test/java/org/folio/circulationbff/service/CheckInServiceTest.java
@@ -6,8 +6,6 @@ import static org.folio.circulationbff.util.TestUtils.randomId;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/MCBFF-176

## Approach
When proxying a check-in call to the secure tenant, account for Claimed returned status of the circulation item.