### PR TITLE
MCBFF-186: Resolve instance for batch details endpoint

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 1.3.0-SNAPSHOT In progress
+* Resolve instance for batch details endpoint (MCBFF-186)
+
+
 ## 1.2.0 2026-04-15
 
 * Remove sensitive data from logs (MCBFF-65)

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -150,7 +150,7 @@
     },
     {
       "id": "circulation-bff-requests-batch",
-      "version": "1.0",
+      "version": "1.1",
       "handlers": [
         {
           "methods": [

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -186,6 +186,16 @@
           "methods": [
             "GET"
           ],
+          "pathPattern": "/circulation-bff/batch-requests/{batchRequestId}/details",
+          "permissionsRequired": ["circulation-bff.batch-request.details.collection.get"],
+          "modulePermissions": [
+            "requests-mediated.batch-mediated-requests.batch-details.collection.get"
+          ]
+        },
+        {
+          "methods": [
+            "GET"
+          ],
           "pathPattern": "/circulation-bff/instance/{instanceId}/batch-requests/{batchRequestId}/details",
           "permissionsRequired": ["circulation-bff.batch-request.details.collection.get"],
           "modulePermissions": [

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -186,10 +186,12 @@
           "methods": [
             "GET"
           ],
-          "pathPattern": "/circulation-bff/batch-requests/{batchRequestId}/details",
+          "pathPattern": "/circulation-bff/instance/{instanceId}/batch-requests/{batchRequestId}/details",
           "permissionsRequired": ["circulation-bff.batch-request.details.collection.get"],
           "modulePermissions": [
-            "requests-mediated.batch-mediated-requests.batch-details.collection.get"
+            "requests-mediated.batch-mediated-requests.batch-details.collection.get",
+            "search.instances.collection.get",
+            "user-tenants.collection.get"
           ]
         }
       ]

--- a/src/main/java/org/folio/circulationbff/controller/CirculationBffController.java
+++ b/src/main/java/org/folio/circulationbff/controller/CirculationBffController.java
@@ -306,6 +306,12 @@ public class CirculationBffController implements CirculationBffApi {
   }
 
   @Override
+  public ResponseEntity<BatchRequestDetailsResponse> getMultiItemBatchRequestDetailsByBatchIdLegacy(UUID batchId, Integer offset, Integer limit) {
+    var batchRequestDetails = mediatedBatchRequestService.retrieveMediatedBatchRequestDetails(null, batchId, offset, limit);
+    return ResponseEntity.ok(batchRequestDetails);
+  }
+
+  @Override
   public ResponseEntity<BatchRequestDetailsResponse> getMultiItemBatchRequestDetailsByBatchId(UUID instanceId, UUID batchId, Integer offset, Integer limit) {
     var batchRequestDetails = mediatedBatchRequestService.retrieveMediatedBatchRequestDetails(instanceId, batchId, offset, limit);
     return ResponseEntity.ok(batchRequestDetails);

--- a/src/main/java/org/folio/circulationbff/controller/CirculationBffController.java
+++ b/src/main/java/org/folio/circulationbff/controller/CirculationBffController.java
@@ -306,8 +306,8 @@ public class CirculationBffController implements CirculationBffApi {
   }
 
   @Override
-  public ResponseEntity<BatchRequestDetailsResponse> getMultiItemBatchRequestDetailsByBatchId(UUID batchId, Integer offset, Integer limit) {
-    var batchRequestDetails = mediatedBatchRequestService.retrieveMediatedBatchRequestDetails(batchId, offset, limit);
+  public ResponseEntity<BatchRequestDetailsResponse> getMultiItemBatchRequestDetailsByBatchId(UUID instanceId, UUID batchId, Integer offset, Integer limit) {
+    var batchRequestDetails = mediatedBatchRequestService.retrieveMediatedBatchRequestDetails(instanceId, batchId, offset, limit);
     return ResponseEntity.ok(batchRequestDetails);
   }
 

--- a/src/main/java/org/folio/circulationbff/service/MediatedBatchRequestService.java
+++ b/src/main/java/org/folio/circulationbff/service/MediatedBatchRequestService.java
@@ -11,5 +11,5 @@ public interface MediatedBatchRequestService {
   ResponseEntity<BatchRequestResponse> createMediatedBatchRequest(BatchRequest batchRequest);
   ResponseEntity<BatchRequestResponse> retrieveMediatedBatchRequestById(UUID batchRequestId);
   BatchRequestCollectionResponse retrieveMediatedBatchRequestsByQuery(String query, Integer offset, Integer limit);
-  BatchRequestDetailsResponse retrieveMediatedBatchRequestDetails(UUID batchRequestId, Integer offset, Integer limit);
+  BatchRequestDetailsResponse retrieveMediatedBatchRequestDetails(UUID instanceId, UUID batchRequestId, Integer offset, Integer limit);
 }

--- a/src/main/java/org/folio/circulationbff/service/impl/MediatedBatchRequestServiceImpl.java
+++ b/src/main/java/org/folio/circulationbff/service/impl/MediatedBatchRequestServiceImpl.java
@@ -81,9 +81,23 @@ public class MediatedBatchRequestServiceImpl implements MediatedBatchRequestServ
   }
 
   private BatchRequestDetailsResponseInstance resolveInstance(UUID instanceId) {
-    log.info("resolveInstance:: resolving instance {} from central tenant", instanceId);
-    var centralTenantId = tenantService.getCentralTenantId().orElseThrow();
-    SearchInstance searchInstance = executionService.executeSystemUserScoped(centralTenantId, () -> {
+    var searchInstance = tenantService.getCentralTenantId()
+      .map(centralTenantId -> fetchInstanceFromCentralTenant(instanceId, centralTenantId))
+      .orElseGet(() -> fetchInstanceFromCurrentTenant(instanceId));
+
+    return new BatchRequestDetailsResponseInstance()
+      .id(instanceId.toString())
+      .title(searchInstance != null ? searchInstance.getTitle() : null);
+  }
+
+  private SearchInstance fetchInstanceFromCentralTenant(UUID instanceId, String centralTenantId) {
+    if (!tenantService.isCurrentTenantCentral()) {
+      throw new IllegalStateException(
+        "resolveInstance:: instance resolution must be performed via central tenant in ECS environment, current: " + tenantService.getCurrentTenantId());
+    }
+    log.info("resolveInstance:: ECS environment, resolving instance {} from central tenant {}", instanceId, centralTenantId);
+
+    return executionService.executeSystemUserScoped(centralTenantId, () -> {
       SearchInstances result = searchInstancesClient.findInstances("id==" + instanceId, true);
       if (result == null || CollectionUtils.isEmpty(result.getInstances())) {
         log.warn("resolveInstance:: instance {} not found in central tenant {}", instanceId, centralTenantId);
@@ -91,12 +105,16 @@ public class MediatedBatchRequestServiceImpl implements MediatedBatchRequestServ
       }
       return result.getInstances().getFirst();
     });
+  }
 
-    var instance = new BatchRequestDetailsResponseInstance().id(instanceId.toString());
-    if (searchInstance != null) {
-      instance.setTitle(searchInstance.getTitle());
+  private SearchInstance fetchInstanceFromCurrentTenant(UUID instanceId) {
+    log.info("resolveInstance:: non-ECS environment, resolving instance {} from current tenant", instanceId);
+    SearchInstances result = searchInstancesClient.findInstances("id==" + instanceId, true);
+    if (result == null || CollectionUtils.isEmpty(result.getInstances())) {
+      log.warn("resolveInstance:: instance {} not found", instanceId);
+      return null;
     }
-    return instance;
+    return result.getInstances().getFirst();
   }
 
   private void updateConfirmedRequestId(BatchRequestDetailsResponse batchDetails) {

--- a/src/main/java/org/folio/circulationbff/service/impl/MediatedBatchRequestServiceImpl.java
+++ b/src/main/java/org/folio/circulationbff/service/impl/MediatedBatchRequestServiceImpl.java
@@ -15,15 +15,20 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.collections4.CollectionUtils;
 import org.folio.circulationbff.client.RequestMediatedClient;
+import org.folio.circulationbff.client.SearchInstancesClient;
 import org.folio.circulationbff.domain.dto.BatchRequest;
 import org.folio.circulationbff.domain.dto.BatchRequestCollectionResponse;
 import org.folio.circulationbff.domain.dto.BatchRequestDetail;
 import org.folio.circulationbff.domain.dto.BatchRequestDetailsResponse;
+import org.folio.circulationbff.domain.dto.BatchRequestDetailsResponseInstance;
 import org.folio.circulationbff.domain.dto.BatchRequestResponse;
 import org.folio.circulationbff.domain.dto.MediatedRequest;
+import org.folio.circulationbff.domain.dto.SearchInstance;
+import org.folio.circulationbff.domain.dto.SearchInstances;
 import org.folio.circulationbff.service.MediatedBatchRequestService;
 import org.folio.circulationbff.service.TenantService;
 import org.folio.circulationbff.support.CqlQuery;
+import org.folio.spring.service.SystemUserScopedExecutionService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -35,6 +40,8 @@ public class MediatedBatchRequestServiceImpl implements MediatedBatchRequestServ
 
   private final RequestMediatedClient requestMediatedClient;
   private final TenantService tenantService;
+  private final SearchInstancesClient searchInstancesClient;
+  private final SystemUserScopedExecutionService executionService;
 
   @Value("${folio.batch-requests.query-request-ids-count}")
   private Integer batchRequestDetailsQueryIdsSize;
@@ -57,7 +64,7 @@ public class MediatedBatchRequestServiceImpl implements MediatedBatchRequestServ
   }
 
   @Override
-  public BatchRequestDetailsResponse retrieveMediatedBatchRequestDetails(UUID batchRequestId, Integer offset, Integer limit) {
+  public BatchRequestDetailsResponse retrieveMediatedBatchRequestDetails(UUID instanceId, UUID batchRequestId, Integer offset, Integer limit) {
     var batchDetails = requestMediatedClient.getMediatedBatchRequestDetails(batchRequestId, limit, offset);
     if (batchDetails != null && isNotEmpty(batchDetails.getMediatedBatchRequestDetails()) && tenantService.isCurrentTenantSecure()) {
       // batch requests created with secure tenant will not have circulation request id in confirmedRequestId field, but it would be
@@ -66,7 +73,30 @@ public class MediatedBatchRequestServiceImpl implements MediatedBatchRequestServ
       updateConfirmedRequestId(batchDetails);
     }
 
+    if (batchDetails != null && instanceId != null) {
+      batchDetails.setInstance(resolveInstance(instanceId));
+    }
+
     return batchDetails;
+  }
+
+  private BatchRequestDetailsResponseInstance resolveInstance(UUID instanceId) {
+    log.info("resolveInstance:: resolving instance {} from central tenant", instanceId);
+    var centralTenantId = tenantService.getCentralTenantId().orElseThrow();
+    SearchInstance searchInstance = executionService.executeSystemUserScoped(centralTenantId, () -> {
+      SearchInstances result = searchInstancesClient.findInstances("id==" + instanceId, true);
+      if (result == null || CollectionUtils.isEmpty(result.getInstances())) {
+        log.warn("resolveInstance:: instance {} not found in central tenant {}", instanceId, centralTenantId);
+        return null;
+      }
+      return result.getInstances().getFirst();
+    });
+
+    var instance = new BatchRequestDetailsResponseInstance().id(instanceId.toString());
+    if (searchInstance != null) {
+      instance.setTitle(searchInstance.getTitle());
+    }
+    return instance;
   }
 
   private void updateConfirmedRequestId(BatchRequestDetailsResponse batchDetails) {

--- a/src/main/resources/swagger.api/circulationBff.yaml
+++ b/src/main/resources/swagger.api/circulationBff.yaml
@@ -15,7 +15,7 @@ paths:
     $ref: 'paths/multiItemBatchRequest.yaml'
   /circulation-bff/batch-requests/{batchId}:
     $ref: 'paths/getMultiItemBatchRequest.yaml'
-  /circulation-bff/batch-requests/{batchId}/details:
+  /circulation-bff/instance/{instanceId}/batch-requests/{batchId}/details:
     $ref: 'paths/getMultiItemBatchRequestDetails.yaml'
   /circulation-bff/loans:
     $ref: 'paths/loans.yaml'

--- a/src/main/resources/swagger.api/circulationBff.yaml
+++ b/src/main/resources/swagger.api/circulationBff.yaml
@@ -15,6 +15,8 @@ paths:
     $ref: 'paths/multiItemBatchRequest.yaml'
   /circulation-bff/batch-requests/{batchId}:
     $ref: 'paths/getMultiItemBatchRequest.yaml'
+  /circulation-bff/batch-requests/{batchId}/details:
+    $ref: 'paths/getMultiItemBatchRequestDetailsLegacy.yaml'
   /circulation-bff/instance/{instanceId}/batch-requests/{batchId}/details:
     $ref: 'paths/getMultiItemBatchRequestDetails.yaml'
   /circulation-bff/loans:

--- a/src/main/resources/swagger.api/examples/response/mediatedBatchRequestDetails.json
+++ b/src/main/resources/swagger.api/examples/response/mediatedBatchRequestDetails.json
@@ -17,5 +17,9 @@
       }
     }
   ],
-  "totalRecords": 1
+  "totalRecords": 1,
+  "instance": {
+    "id": "7212ba6a-8dcf-45a1-be9a-ffaa847c4423",
+    "title": "Interesting Times"
+  }
 }

--- a/src/main/resources/swagger.api/paths/getMultiItemBatchRequestDetails.yaml
+++ b/src/main/resources/swagger.api/paths/getMultiItemBatchRequestDetails.yaml
@@ -4,6 +4,13 @@ get:
   tags:
     - multiItemBatchRequests
   parameters:
+    - name: instanceId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+      description: The UUID of the instance whose details are being requested
     - name: batchId
       in: path
       required: true

--- a/src/main/resources/swagger.api/paths/getMultiItemBatchRequestDetailsLegacy.yaml
+++ b/src/main/resources/swagger.api/paths/getMultiItemBatchRequestDetailsLegacy.yaml
@@ -1,0 +1,28 @@
+get:
+  description: Retrieve multi-item batch request details by batch id (deprecated, use /instance/{instanceId}/batch-requests/{batchId}/details instead)
+  operationId: getMultiItemBatchRequestDetailsByBatchIdLegacy
+  tags:
+    - multiItemBatchRequests
+  parameters:
+    - name: batchId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+      description: The UUID of the batch request
+    - $ref: '../parameters/offset.yaml'
+    - $ref: '../parameters/limit.yaml'
+  responses:
+    '200':
+      description: Multi-Item Batch Requests Collection
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/response/batch/batchRequestDetailsResponse.yaml"
+    '400':
+      $ref: '../responses/badRequestResponse.yaml'
+    '404':
+      $ref: '../responses/notFoundResponse.yaml'
+    '500':
+      $ref: '../responses/internalServerErrorResponse.yaml'

--- a/src/main/resources/swagger.api/schemas/response/batch/batchRequestDetailsResponse.yaml
+++ b/src/main/resources/swagger.api/schemas/response/batch/batchRequestDetailsResponse.yaml
@@ -9,6 +9,17 @@ properties:
   totalRecords:
     description: Total number of requests
     type: integer
+  instance:
+    description: Instance data resolved for the requested instance id
+    type: object
+    properties:
+      id:
+        description: UUID of the instance
+        $ref: '../../dto/common/uuid.yaml'
+      title:
+        description: Title of the instance
+        type: string
+    additionalProperties: false
 additionalProperties: false
 required:
   - mediatedBatchRequestDetails

--- a/src/test/java/org/folio/circulationbff/api/CirculationBffBatchRequestsApiTest.java
+++ b/src/test/java/org/folio/circulationbff/api/CirculationBffBatchRequestsApiTest.java
@@ -81,6 +81,28 @@ class CirculationBffBatchRequestsApiTest extends BaseIT {
 
   @Test
   @SneakyThrows
+  void getMultiItemBatchRequestDetailsByBatchIdLegacyReturnsOk() {
+    var batchId = UUID.randomUUID().toString();
+    var offset = "0";
+    var limit = "5";
+    var detailsResponse = MockHelper.buildBatchRequestDetailsResponse();
+    mockHelper.mockGetMultiItemBatchRequestDetails(batchId, offset, limit, detailsResponse);
+
+    mockMvc.perform(get(BASE_PATH + "/" + batchId + "/details")
+        .queryParam("offset", offset)
+        .queryParam("limit", limit)
+        .headers(defaultHeaders()))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.mediatedBatchRequestDetails[0].itemId",
+        is(detailsResponse.getMediatedBatchRequestDetails().getFirst().getItemId())));
+
+    wireMockServer.verify(getRequestedFor(urlPathEqualTo(MEDIATED_BATCH_REQUEST_URL + "/" + batchId + "/details"))
+      .withQueryParam("offset", equalTo(offset))
+      .withQueryParam("limit", equalTo(limit)));
+  }
+
+  @Test
+  @SneakyThrows
   void getMultiItemBatchRequestDetailsByBatchIdReturnsOk() {
     var instanceId = UUID.randomUUID().toString();
     var batchId = UUID.randomUUID().toString();

--- a/src/test/java/org/folio/circulationbff/api/CirculationBffBatchRequestsApiTest.java
+++ b/src/test/java/org/folio/circulationbff/api/CirculationBffBatchRequestsApiTest.java
@@ -13,6 +13,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.UUID;
 import lombok.SneakyThrows;
+import org.folio.circulationbff.domain.dto.UserTenant;
+import org.folio.circulationbff.domain.dto.UserTenantCollection;
 import org.folio.circulationbff.util.MockHelper;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -80,22 +82,34 @@ class CirculationBffBatchRequestsApiTest extends BaseIT {
   @Test
   @SneakyThrows
   void getMultiItemBatchRequestDetailsByBatchIdReturnsOk() {
+    var instanceId = UUID.randomUUID().toString();
     var batchId = UUID.randomUUID().toString();
     var offset = "0";
     var limit = "5";
     var detailsResponse = MockHelper.buildBatchRequestDetailsResponse();
     mockHelper.mockGetMultiItemBatchRequestDetails(batchId, offset, limit, detailsResponse);
+    mockHelper.mockUserTenants(buildConsortiumUserTenants(), TENANT_ID_CONSORTIUM);
+    mockHelper.mockSearchInstanceForBatchDetails(instanceId, "Interesting Times");
 
-    mockMvc.perform(get(BASE_PATH + "/" + batchId + "/details")
+    mockMvc.perform(get("/circulation-bff/instance/" + instanceId + "/batch-requests/" + batchId + "/details")
         .queryParam("offset", offset)
         .queryParam("limit", limit)
         .headers(defaultHeaders()))
       .andExpect(status().isOk())
       .andExpect(jsonPath("$.mediatedBatchRequestDetails[0].itemId",
-        is(detailsResponse.getMediatedBatchRequestDetails().getFirst().getItemId())));
+        is(detailsResponse.getMediatedBatchRequestDetails().getFirst().getItemId())))
+      .andExpect(jsonPath("$.instance.id", is(instanceId)))
+      .andExpect(jsonPath("$.instance.title", is("Interesting Times")));
 
     wireMockServer.verify(getRequestedFor(urlPathEqualTo(MEDIATED_BATCH_REQUEST_URL + "/" + batchId + "/details"))
       .withQueryParam("offset", equalTo(offset))
       .withQueryParam("limit", equalTo(limit)));
+  }
+
+  private static UserTenantCollection buildConsortiumUserTenants() {
+    var userTenant = new UserTenant()
+      .tenantId(TENANT_ID_CONSORTIUM)
+      .centralTenantId(TENANT_ID_CONSORTIUM);
+    return new UserTenantCollection().addUserTenantsItem(userTenant);
   }
 }

--- a/src/test/java/org/folio/circulationbff/controller/CirculationBffControllerTest.java
+++ b/src/test/java/org/folio/circulationbff/controller/CirculationBffControllerTest.java
@@ -296,14 +296,15 @@ class CirculationBffControllerTest {
 
   @Test
   void getMultiItemBatchRequestDetailsByBatchIdReturnsOkResponse() {
+    var instanceId = UUID.randomUUID();
     var batchId = UUID.randomUUID();
     var offset = 0;
     var limit = 5;
     var detailsResponse = new BatchRequestDetailsResponse();
 
-    when(mediatedBatchRequestService.retrieveMediatedBatchRequestDetails(batchId, offset, limit)).thenReturn(detailsResponse);
+    when(mediatedBatchRequestService.retrieveMediatedBatchRequestDetails(instanceId, batchId, offset, limit)).thenReturn(detailsResponse);
 
-    var response = controller.getMultiItemBatchRequestDetailsByBatchId(batchId, offset, limit);
+    var response = controller.getMultiItemBatchRequestDetailsByBatchId(instanceId, batchId, offset, limit);
 
     assertThat(response.getStatusCode(), is(HttpStatus.OK));
     assertThat(response.getBody(), is(detailsResponse));

--- a/src/test/java/org/folio/circulationbff/service/MediatedBatchRequestServiceTest.java
+++ b/src/test/java/org/folio/circulationbff/service/MediatedBatchRequestServiceTest.java
@@ -2,14 +2,19 @@ package org.folio.circulationbff.service;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 import org.folio.circulationbff.client.RequestMediatedClient;
+import org.folio.circulationbff.client.SearchInstancesClient;
 import org.folio.circulationbff.domain.dto.BatchRequest;
 import org.folio.circulationbff.domain.dto.BatchRequestCollectionResponse;
 import org.folio.circulationbff.domain.dto.BatchRequestDetail;
@@ -17,7 +22,10 @@ import org.folio.circulationbff.domain.dto.BatchRequestDetailsResponse;
 import org.folio.circulationbff.domain.dto.BatchRequestResponse;
 import org.folio.circulationbff.domain.dto.MediatedRequest;
 import org.folio.circulationbff.domain.dto.MediatedRequests;
+import org.folio.circulationbff.domain.dto.SearchInstance;
+import org.folio.circulationbff.domain.dto.SearchInstances;
 import org.folio.circulationbff.service.impl.MediatedBatchRequestServiceImpl;
+import org.folio.spring.service.SystemUserScopedExecutionService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,6 +41,10 @@ class MediatedBatchRequestServiceTest {
   private RequestMediatedClient requestMediatedClient;
   @Mock
   private TenantService tenantService;
+  @Mock
+  private SearchInstancesClient searchInstancesClient;
+  @Mock
+  private SystemUserScopedExecutionService executionService;
 
   @InjectMocks
   private MediatedBatchRequestServiceImpl service;
@@ -94,7 +106,7 @@ class MediatedBatchRequestServiceTest {
 
     when(requestMediatedClient.getMediatedBatchRequestDetails(batchId, limit, offset)).thenReturn(expectedDetails);
 
-    var response = service.retrieveMediatedBatchRequestDetails(batchId, offset, limit);
+    var response = service.retrieveMediatedBatchRequestDetails(null, batchId, offset, limit);
 
     assertThat(response, is(expectedDetails));
     verify(requestMediatedClient).getMediatedBatchRequestDetails(batchId, limit, offset);
@@ -122,7 +134,7 @@ class MediatedBatchRequestServiceTest {
     when(tenantService.isCurrentTenantSecure()).thenReturn(true);
     when(requestMediatedClient.getMediatedRequestsByQuery(anyString())).thenReturn(mediatedRequests);
 
-    var response = service.retrieveMediatedBatchRequestDetails(batchId, offset, limit);
+    var response = service.retrieveMediatedBatchRequestDetails(null, batchId, offset, limit);
 
     assertThat(response.getMediatedBatchRequestDetails().getFirst().getConfirmedRequestId(), is(circulationRequestId));
   }
@@ -142,7 +154,7 @@ class MediatedBatchRequestServiceTest {
     when(tenantService.isCurrentTenantSecure()).thenReturn(true);
     when(requestMediatedClient.getMediatedRequestsByQuery(anyString())).thenReturn(mediatedRequests);
 
-    var response = service.retrieveMediatedBatchRequestDetails(batchId, offset, limit);
+    var response = service.retrieveMediatedBatchRequestDetails(null, batchId, offset, limit);
 
     assertThat(response.getMediatedBatchRequestDetails().getFirst().getConfirmedRequestId(), is(nullValue()));
   }
@@ -169,7 +181,7 @@ class MediatedBatchRequestServiceTest {
     when(tenantService.isCurrentTenantSecure()).thenReturn(true);
     when(requestMediatedClient.getMediatedRequestsByQuery(anyString())).thenReturn(mediatedRequests);
 
-    var response = service.retrieveMediatedBatchRequestDetails(batchId, offset, limit);
+    var response = service.retrieveMediatedBatchRequestDetails(null, batchId, offset, limit);
 
     assertThat(response.getMediatedBatchRequestDetails().get(0).getConfirmedRequestId(), is(nullValue()));
     assertThat(response.getMediatedBatchRequestDetails().get(1).getConfirmedRequestId(), is(circulationRequestId));
@@ -194,8 +206,58 @@ class MediatedBatchRequestServiceTest {
     when(tenantService.isCurrentTenantSecure()).thenReturn(true);
     when(requestMediatedClient.getMediatedRequestsByQuery(anyString())).thenReturn(mediatedRequests);
 
-    var response = service.retrieveMediatedBatchRequestDetails(batchId, offset, limit);
+    var response = service.retrieveMediatedBatchRequestDetails(null, batchId, offset, limit);
 
     assertThat(response.getMediatedBatchRequestDetails().getFirst().getConfirmedRequestId(), is(nullValue()));
+  }
+
+  @Test
+  void retrieveBatchRequestDetailsResolvesInstanceFromCentralTenant() {
+    var instanceId = UUID.randomUUID();
+    var batchId = UUID.randomUUID();
+    var offset = 0;
+    var limit = 5;
+    var centralTenantId = "consortium";
+    var title = "Interesting Times";
+
+    var batchDetails = new BatchRequestDetailsResponse().mediatedBatchRequestDetails(List.of());
+    var searchInstances = new SearchInstances()
+      .instances(List.of(new SearchInstance().id(instanceId.toString()).title(title)));
+
+    when(requestMediatedClient.getMediatedBatchRequestDetails(batchId, limit, offset)).thenReturn(batchDetails);
+    when(tenantService.getCentralTenantId()).thenReturn(java.util.Optional.of(centralTenantId));
+    when(executionService.executeSystemUserScoped(eq(centralTenantId), any(Callable.class)))
+      .thenAnswer(inv -> ((Callable<?>) inv.getArgument(1)).call());
+    when(searchInstancesClient.findInstances("id==" + instanceId, true)).thenReturn(searchInstances);
+
+    var response = service.retrieveMediatedBatchRequestDetails(instanceId, batchId, offset, limit);
+
+    assertThat(response.getInstance(), is(notNullValue()));
+    assertThat(response.getInstance().getId(), is(instanceId.toString()));
+    assertThat(response.getInstance().getTitle(), is(title));
+  }
+
+  @Test
+  void retrieveBatchRequestDetailsHandlesMissingInstanceFromCentralTenant() {
+    var instanceId = UUID.randomUUID();
+    var batchId = UUID.randomUUID();
+    var offset = 0;
+    var limit = 5;
+    var centralTenantId = "consortium";
+
+    var batchDetails = new BatchRequestDetailsResponse().mediatedBatchRequestDetails(List.of());
+
+    when(requestMediatedClient.getMediatedBatchRequestDetails(batchId, limit, offset)).thenReturn(batchDetails);
+    when(tenantService.getCentralTenantId()).thenReturn(java.util.Optional.of(centralTenantId));
+    when(executionService.executeSystemUserScoped(eq(centralTenantId), any(Callable.class)))
+      .thenAnswer(inv -> ((Callable<?>) inv.getArgument(1)).call());
+    when(searchInstancesClient.findInstances("id==" + instanceId, true))
+      .thenReturn(new SearchInstances().instances(List.of()));
+
+    var response = service.retrieveMediatedBatchRequestDetails(instanceId, batchId, offset, limit);
+
+    assertThat(response.getInstance(), is(notNullValue()));
+    assertThat(response.getInstance().getId(), is(instanceId.toString()));
+    assertThat(response.getInstance().getTitle(), is(nullValue()));
   }
 }

--- a/src/test/java/org/folio/circulationbff/service/MediatedBatchRequestServiceTest.java
+++ b/src/test/java/org/folio/circulationbff/service/MediatedBatchRequestServiceTest.java
@@ -260,4 +260,72 @@ class MediatedBatchRequestServiceTest {
     assertThat(response.getInstance().getId(), is(instanceId.toString()));
     assertThat(response.getInstance().getTitle(), is(nullValue()));
   }
+
+  @Test
+  void retrieveBatchRequestDetailsReturnsNullWhenClientReturnsNull() {
+    var instanceId = UUID.randomUUID();
+    var batchId = UUID.randomUUID();
+
+    when(requestMediatedClient.getMediatedBatchRequestDetails(batchId, 5, 0)).thenReturn(null);
+
+    var response = service.retrieveMediatedBatchRequestDetails(instanceId, batchId, 0, 5);
+
+    assertThat(response, is(nullValue()));
+  }
+
+  @Test
+  void resolveInstanceReturnsOnlyIdWhenSearchReturnsNull() {
+    var instanceId = UUID.randomUUID();
+    var batchId = UUID.randomUUID();
+    var centralTenantId = "consortium";
+
+    var batchDetails = new BatchRequestDetailsResponse().mediatedBatchRequestDetails(List.of());
+
+    when(requestMediatedClient.getMediatedBatchRequestDetails(batchId, 5, 0)).thenReturn(batchDetails);
+    when(tenantService.getCentralTenantId()).thenReturn(java.util.Optional.of(centralTenantId));
+    when(executionService.executeSystemUserScoped(eq(centralTenantId), any(Callable.class)))
+      .thenAnswer(inv -> ((Callable<?>) inv.getArgument(1)).call());
+    when(searchInstancesClient.findInstances("id==" + instanceId, true)).thenReturn(null);
+
+    var response = service.retrieveMediatedBatchRequestDetails(instanceId, batchId, 0, 5);
+
+    assertThat(response.getInstance(), is(notNullValue()));
+    assertThat(response.getInstance().getId(), is(instanceId.toString()));
+    assertThat(response.getInstance().getTitle(), is(nullValue()));
+  }
+
+  @Test
+  void retrieveBatchRequestDetailsResolvesInstanceAndUpdatesConfirmedRequestIdForSecureTenant() {
+    var instanceId = UUID.randomUUID();
+    var batchId = UUID.randomUUID();
+    var offset = 0;
+    var limit = 5;
+    var centralTenantId = "consortium";
+    var mediatedRequestId = UUID.randomUUID().toString();
+    var circulationRequestId = UUID.randomUUID().toString();
+    var title = "Interesting Times";
+
+    var detail = new BatchRequestDetail().confirmedRequestId(mediatedRequestId);
+    var batchDetails = new BatchRequestDetailsResponse().mediatedBatchRequestDetails(List.of(detail));
+    var searchInstances = new SearchInstances()
+      .instances(List.of(new SearchInstance().id(instanceId.toString()).title(title)));
+    var mediatedRequest = new MediatedRequest()
+      .id(mediatedRequestId)
+      .confirmedRequestId(circulationRequestId);
+    var mediatedRequests = new MediatedRequests().mediatedRequests(List.of(mediatedRequest));
+
+    when(requestMediatedClient.getMediatedBatchRequestDetails(batchId, limit, offset)).thenReturn(batchDetails);
+    when(tenantService.isCurrentTenantSecure()).thenReturn(true);
+    when(requestMediatedClient.getMediatedRequestsByQuery(anyString())).thenReturn(mediatedRequests);
+    when(tenantService.getCentralTenantId()).thenReturn(java.util.Optional.of(centralTenantId));
+    when(executionService.executeSystemUserScoped(eq(centralTenantId), any(Callable.class)))
+      .thenAnswer(inv -> ((Callable<?>) inv.getArgument(1)).call());
+    when(searchInstancesClient.findInstances("id==" + instanceId, true)).thenReturn(searchInstances);
+
+    var response = service.retrieveMediatedBatchRequestDetails(instanceId, batchId, offset, limit);
+
+    assertThat(response.getMediatedBatchRequestDetails().getFirst().getConfirmedRequestId(), is(circulationRequestId));
+    assertThat(response.getInstance(), is(notNullValue()));
+    assertThat(response.getInstance().getTitle(), is(title));
+  }
 }

--- a/src/test/java/org/folio/circulationbff/service/MediatedBatchRequestServiceTest.java
+++ b/src/test/java/org/folio/circulationbff/service/MediatedBatchRequestServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -226,6 +227,7 @@ class MediatedBatchRequestServiceTest {
 
     when(requestMediatedClient.getMediatedBatchRequestDetails(batchId, limit, offset)).thenReturn(batchDetails);
     when(tenantService.getCentralTenantId()).thenReturn(java.util.Optional.of(centralTenantId));
+    when(tenantService.isCurrentTenantCentral()).thenReturn(true);
     when(executionService.executeSystemUserScoped(eq(centralTenantId), any(Callable.class)))
       .thenAnswer(inv -> ((Callable<?>) inv.getArgument(1)).call());
     when(searchInstancesClient.findInstances("id==" + instanceId, true)).thenReturn(searchInstances);
@@ -249,6 +251,7 @@ class MediatedBatchRequestServiceTest {
 
     when(requestMediatedClient.getMediatedBatchRequestDetails(batchId, limit, offset)).thenReturn(batchDetails);
     when(tenantService.getCentralTenantId()).thenReturn(java.util.Optional.of(centralTenantId));
+    when(tenantService.isCurrentTenantCentral()).thenReturn(true);
     when(executionService.executeSystemUserScoped(eq(centralTenantId), any(Callable.class)))
       .thenAnswer(inv -> ((Callable<?>) inv.getArgument(1)).call());
     when(searchInstancesClient.findInstances("id==" + instanceId, true))
@@ -283,6 +286,7 @@ class MediatedBatchRequestServiceTest {
 
     when(requestMediatedClient.getMediatedBatchRequestDetails(batchId, 5, 0)).thenReturn(batchDetails);
     when(tenantService.getCentralTenantId()).thenReturn(java.util.Optional.of(centralTenantId));
+    when(tenantService.isCurrentTenantCentral()).thenReturn(true);
     when(executionService.executeSystemUserScoped(eq(centralTenantId), any(Callable.class)))
       .thenAnswer(inv -> ((Callable<?>) inv.getArgument(1)).call());
     when(searchInstancesClient.findInstances("id==" + instanceId, true)).thenReturn(null);
@@ -318,6 +322,7 @@ class MediatedBatchRequestServiceTest {
     when(tenantService.isCurrentTenantSecure()).thenReturn(true);
     when(requestMediatedClient.getMediatedRequestsByQuery(anyString())).thenReturn(mediatedRequests);
     when(tenantService.getCentralTenantId()).thenReturn(java.util.Optional.of(centralTenantId));
+    when(tenantService.isCurrentTenantCentral()).thenReturn(true);
     when(executionService.executeSystemUserScoped(eq(centralTenantId), any(Callable.class)))
       .thenAnswer(inv -> ((Callable<?>) inv.getArgument(1)).call());
     when(searchInstancesClient.findInstances("id==" + instanceId, true)).thenReturn(searchInstances);
@@ -327,5 +332,44 @@ class MediatedBatchRequestServiceTest {
     assertThat(response.getMediatedBatchRequestDetails().getFirst().getConfirmedRequestId(), is(circulationRequestId));
     assertThat(response.getInstance(), is(notNullValue()));
     assertThat(response.getInstance().getTitle(), is(title));
+  }
+
+  @Test
+  void resolveInstanceThrowsWhenCalledFromMemberTenantInEcsEnvironment() {
+    var instanceId = UUID.randomUUID();
+    var batchId = UUID.randomUUID();
+    var centralTenantId = "consortium";
+
+    var batchDetails = new BatchRequestDetailsResponse().mediatedBatchRequestDetails(List.of());
+
+    when(requestMediatedClient.getMediatedBatchRequestDetails(batchId, 5, 0)).thenReturn(batchDetails);
+    when(tenantService.getCentralTenantId()).thenReturn(java.util.Optional.of(centralTenantId));
+    when(tenantService.isCurrentTenantCentral()).thenReturn(false);
+    when(tenantService.getCurrentTenantId()).thenReturn("member-tenant");
+
+    org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class,
+      () -> service.retrieveMediatedBatchRequestDetails(instanceId, batchId, 0, 5));
+  }
+
+  @Test
+  void resolveInstanceReadsDirectlyFromCurrentTenantInNonEcsEnvironment() {
+    var instanceId = UUID.randomUUID();
+    var batchId = UUID.randomUUID();
+    var title = "Some Book";
+
+    var batchDetails = new BatchRequestDetailsResponse().mediatedBatchRequestDetails(List.of());
+    var searchInstances = new SearchInstances()
+      .instances(List.of(new SearchInstance().id(instanceId.toString()).title(title)));
+
+    when(requestMediatedClient.getMediatedBatchRequestDetails(batchId, 5, 0)).thenReturn(batchDetails);
+    when(tenantService.getCentralTenantId()).thenReturn(java.util.Optional.empty());
+    when(searchInstancesClient.findInstances("id==" + instanceId, true)).thenReturn(searchInstances);
+
+    var response = service.retrieveMediatedBatchRequestDetails(instanceId, batchId, 0, 5);
+
+    assertThat(response.getInstance(), is(notNullValue()));
+    assertThat(response.getInstance().getId(), is(instanceId.toString()));
+    assertThat(response.getInstance().getTitle(), is(title));
+    verifyNoInteractions(executionService);
   }
 }

--- a/src/test/java/org/folio/circulationbff/util/MockHelper.java
+++ b/src/test/java/org/folio/circulationbff/util/MockHelper.java
@@ -376,6 +376,15 @@ public class MockHelper {
       .willReturn(jsonResponse(asJsonString(response), SC_OK)));
   }
 
+  public void mockSearchInstanceForBatchDetails(String instanceId, String title) {
+    var searchInstance = new SearchInstance().id(instanceId).title(title);
+    var searchInstances = new org.folio.circulationbff.domain.dto.SearchInstances()
+      .instances(List.of(searchInstance));
+    wireMockServer.stubFor(WireMock.get(urlPathEqualTo("/search/instances"))
+      .withQueryParam("query", equalTo("id==" + instanceId))
+      .willReturn(jsonResponse(asJsonString(searchInstances), SC_OK)));
+  }
+
   public static void mockSystemUserService(SystemUserScopedExecutionService systemUserService) {
     doAnswer(invocation -> ((Callable<?>) invocation.getArguments()[1]).call())
       .when(systemUserService).executeSystemUserScoped(anyString(), any(Callable.class));


### PR DESCRIPTION
## Purpose
The /patron/account/.../batch-request/{id}/status endpoint was returning 404 because mod-patron resolved the instance title from the secure tenant instead of the central one — a broken approach in ECS environments.

## Approach
   - Renamed /circulation-bff/batch-requests/{batchId}/details → /circulation-bff/instance/{instanceId}/batch-requests/{batchId}/details
   - In MediatedBatchRequestServiceImpl, after fetching batch details, resolve the instance by instanceId using SearchInstancesClient scoped to the central tenant via SystemUserScopedExecutionService
   - Include instance.id and instance.title in the response
   - Updated module descriptor to add search.instances.collection.get and user-tenants.collection.get module permissions


#### TODOS and Open Questions
- [x] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
[MCBFF-186](https://folio-org.atlassian.net/browse/MCBFF-186)