### PR TITLE
MCBFF-186: Remove unnecessary tenant check in instance resolution

### DIFF
--- a/src/main/java/org/folio/circulationbff/service/impl/MediatedBatchRequestServiceImpl.java
+++ b/src/main/java/org/folio/circulationbff/service/impl/MediatedBatchRequestServiceImpl.java
@@ -91,12 +91,7 @@ public class MediatedBatchRequestServiceImpl implements MediatedBatchRequestServ
   }
 
   private SearchInstance fetchInstanceFromCentralTenant(UUID instanceId, String centralTenantId) {
-    if (!tenantService.isCurrentTenantCentral()) {
-      throw new IllegalStateException(
-        "resolveInstance:: instance resolution must be performed via central tenant in ECS environment, current: " + tenantService.getCurrentTenantId());
-    }
     log.info("resolveInstance:: ECS environment, resolving instance {} from central tenant {}", instanceId, centralTenantId);
-
     return executionService.executeSystemUserScoped(centralTenantId, () -> {
       SearchInstances result = searchInstancesClient.findInstances("id==" + instanceId, true);
       if (result == null || CollectionUtils.isEmpty(result.getInstances())) {

--- a/src/test/java/org/folio/circulationbff/api/CirculationBffBatchRequestsApiTest.java
+++ b/src/test/java/org/folio/circulationbff/api/CirculationBffBatchRequestsApiTest.java
@@ -12,11 +12,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.UUID;
+import java.util.stream.Stream;
+
 import lombok.SneakyThrows;
 import org.folio.circulationbff.domain.dto.UserTenant;
 import org.folio.circulationbff.domain.dto.UserTenantCollection;
 import org.folio.circulationbff.util.MockHelper;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.MediaType;
 
 
@@ -128,9 +132,10 @@ class CirculationBffBatchRequestsApiTest extends BaseIT {
       .withQueryParam("limit", equalTo(limit)));
   }
 
-  @Test
+  @ParameterizedTest
+  @MethodSource("nonCentralTenantIds")
   @SneakyThrows
-  void getMultiItemBatchRequestDetailsByBatchIdFromMemberTenantReturnsOk() {
+  void getMultiItemBatchRequestDetailsByBatchIdFromNonCentralTenantReturnsOk(String tenantId) {
     var instanceId = UUID.randomUUID().toString();
     var batchId = UUID.randomUUID().toString();
     var offset = "0";
@@ -139,55 +144,22 @@ class CirculationBffBatchRequestsApiTest extends BaseIT {
     mockHelper.mockGetMultiItemBatchRequestDetails(batchId, offset, limit, detailsResponse);
 
     var userTenant = new UserTenant()
-      .tenantId(TENANT_ID_COLLEGE)
+      .tenantId(tenantId)
       .centralTenantId(TENANT_ID_CONSORTIUM);
-    mockHelper.mockUserTenants(new UserTenantCollection().addUserTenantsItem(userTenant), TENANT_ID_COLLEGE);
+    mockHelper.mockUserTenants(new UserTenantCollection().addUserTenantsItem(userTenant), tenantId);
     mockHelper.mockSearchInstanceForBatchDetails(instanceId, "Interesting Times");
 
     mockMvc.perform(get("/circulation-bff/instance/" + instanceId + "/batch-requests/" + batchId + "/details")
         .queryParam("offset", offset)
         .queryParam("limit", limit)
-        .headers(buildHeaders(TENANT_ID_COLLEGE)))
+        .headers(buildHeaders(tenantId)))
       .andExpect(status().isOk())
-      .andExpect(jsonPath("$.mediatedBatchRequestDetails[0].itemId",
-        is(detailsResponse.getMediatedBatchRequestDetails().getFirst().getItemId())))
       .andExpect(jsonPath("$.instance.id", is(instanceId)))
       .andExpect(jsonPath("$.instance.title", is("Interesting Times")));
-
-    wireMockServer.verify(getRequestedFor(urlPathEqualTo(MEDIATED_BATCH_REQUEST_URL + "/" + batchId + "/details"))
-      .withQueryParam("offset", equalTo(offset))
-      .withQueryParam("limit", equalTo(limit)));
   }
 
-  @Test
-  @SneakyThrows
-  void getMultiItemBatchRequestDetailsByBatchIdFromSecureTenantReturnsOk() {
-    var instanceId = UUID.randomUUID().toString();
-    var batchId = UUID.randomUUID().toString();
-    var offset = "0";
-    var limit = "5";
-    var detailsResponse = MockHelper.buildBatchRequestDetailsResponse();
-    mockHelper.mockGetMultiItemBatchRequestDetails(batchId, offset, limit, detailsResponse);
-
-    var userTenant = new UserTenant()
-      .tenantId(TENANT_ID_SECURE)
-      .centralTenantId(TENANT_ID_CONSORTIUM);
-    mockHelper.mockUserTenants(new UserTenantCollection().addUserTenantsItem(userTenant), TENANT_ID_SECURE);
-    mockHelper.mockSearchInstanceForBatchDetails(instanceId, "Interesting Times");
-
-    mockMvc.perform(get("/circulation-bff/instance/" + instanceId + "/batch-requests/" + batchId + "/details")
-        .queryParam("offset", offset)
-        .queryParam("limit", limit)
-        .headers(buildHeaders(TENANT_ID_SECURE)))
-      .andExpect(status().isOk())
-      .andExpect(jsonPath("$.mediatedBatchRequestDetails[0].itemId",
-        is(detailsResponse.getMediatedBatchRequestDetails().getFirst().getItemId())))
-      .andExpect(jsonPath("$.instance.id", is(instanceId)))
-      .andExpect(jsonPath("$.instance.title", is("Interesting Times")));
-
-    wireMockServer.verify(getRequestedFor(urlPathEqualTo(MEDIATED_BATCH_REQUEST_URL + "/" + batchId + "/details"))
-      .withQueryParam("offset", equalTo(offset))
-      .withQueryParam("limit", equalTo(limit)));
+  private static Stream<String> nonCentralTenantIds() {
+    return Stream.of(TENANT_ID_COLLEGE, TENANT_ID_SECURE);
   }
 
   private static UserTenantCollection buildConsortiumUserTenants() {

--- a/src/test/java/org/folio/circulationbff/api/CirculationBffBatchRequestsApiTest.java
+++ b/src/test/java/org/folio/circulationbff/api/CirculationBffBatchRequestsApiTest.java
@@ -128,6 +128,68 @@ class CirculationBffBatchRequestsApiTest extends BaseIT {
       .withQueryParam("limit", equalTo(limit)));
   }
 
+  @Test
+  @SneakyThrows
+  void getMultiItemBatchRequestDetailsByBatchIdFromMemberTenantReturnsOk() {
+    var instanceId = UUID.randomUUID().toString();
+    var batchId = UUID.randomUUID().toString();
+    var offset = "0";
+    var limit = "5";
+    var detailsResponse = MockHelper.buildBatchRequestDetailsResponse();
+    mockHelper.mockGetMultiItemBatchRequestDetails(batchId, offset, limit, detailsResponse);
+
+    var userTenant = new UserTenant()
+      .tenantId(TENANT_ID_COLLEGE)
+      .centralTenantId(TENANT_ID_CONSORTIUM);
+    mockHelper.mockUserTenants(new UserTenantCollection().addUserTenantsItem(userTenant), TENANT_ID_COLLEGE);
+    mockHelper.mockSearchInstanceForBatchDetails(instanceId, "Interesting Times");
+
+    mockMvc.perform(get("/circulation-bff/instance/" + instanceId + "/batch-requests/" + batchId + "/details")
+        .queryParam("offset", offset)
+        .queryParam("limit", limit)
+        .headers(buildHeaders(TENANT_ID_COLLEGE)))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.mediatedBatchRequestDetails[0].itemId",
+        is(detailsResponse.getMediatedBatchRequestDetails().getFirst().getItemId())))
+      .andExpect(jsonPath("$.instance.id", is(instanceId)))
+      .andExpect(jsonPath("$.instance.title", is("Interesting Times")));
+
+    wireMockServer.verify(getRequestedFor(urlPathEqualTo(MEDIATED_BATCH_REQUEST_URL + "/" + batchId + "/details"))
+      .withQueryParam("offset", equalTo(offset))
+      .withQueryParam("limit", equalTo(limit)));
+  }
+
+  @Test
+  @SneakyThrows
+  void getMultiItemBatchRequestDetailsByBatchIdFromSecureTenantReturnsOk() {
+    var instanceId = UUID.randomUUID().toString();
+    var batchId = UUID.randomUUID().toString();
+    var offset = "0";
+    var limit = "5";
+    var detailsResponse = MockHelper.buildBatchRequestDetailsResponse();
+    mockHelper.mockGetMultiItemBatchRequestDetails(batchId, offset, limit, detailsResponse);
+
+    var userTenant = new UserTenant()
+      .tenantId(TENANT_ID_SECURE)
+      .centralTenantId(TENANT_ID_CONSORTIUM);
+    mockHelper.mockUserTenants(new UserTenantCollection().addUserTenantsItem(userTenant), TENANT_ID_SECURE);
+    mockHelper.mockSearchInstanceForBatchDetails(instanceId, "Interesting Times");
+
+    mockMvc.perform(get("/circulation-bff/instance/" + instanceId + "/batch-requests/" + batchId + "/details")
+        .queryParam("offset", offset)
+        .queryParam("limit", limit)
+        .headers(buildHeaders(TENANT_ID_SECURE)))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.mediatedBatchRequestDetails[0].itemId",
+        is(detailsResponse.getMediatedBatchRequestDetails().getFirst().getItemId())))
+      .andExpect(jsonPath("$.instance.id", is(instanceId)))
+      .andExpect(jsonPath("$.instance.title", is("Interesting Times")));
+
+    wireMockServer.verify(getRequestedFor(urlPathEqualTo(MEDIATED_BATCH_REQUEST_URL + "/" + batchId + "/details"))
+      .withQueryParam("offset", equalTo(offset))
+      .withQueryParam("limit", equalTo(limit)));
+  }
+
   private static UserTenantCollection buildConsortiumUserTenants() {
     var userTenant = new UserTenant()
       .tenantId(TENANT_ID_CONSORTIUM)

--- a/src/test/java/org/folio/circulationbff/service/MediatedBatchRequestServiceTest.java
+++ b/src/test/java/org/folio/circulationbff/service/MediatedBatchRequestServiceTest.java
@@ -227,7 +227,6 @@ class MediatedBatchRequestServiceTest {
 
     when(requestMediatedClient.getMediatedBatchRequestDetails(batchId, limit, offset)).thenReturn(batchDetails);
     when(tenantService.getCentralTenantId()).thenReturn(java.util.Optional.of(centralTenantId));
-    when(tenantService.isCurrentTenantCentral()).thenReturn(true);
     when(executionService.executeSystemUserScoped(eq(centralTenantId), any(Callable.class)))
       .thenAnswer(inv -> ((Callable<?>) inv.getArgument(1)).call());
     when(searchInstancesClient.findInstances("id==" + instanceId, true)).thenReturn(searchInstances);
@@ -251,7 +250,6 @@ class MediatedBatchRequestServiceTest {
 
     when(requestMediatedClient.getMediatedBatchRequestDetails(batchId, limit, offset)).thenReturn(batchDetails);
     when(tenantService.getCentralTenantId()).thenReturn(java.util.Optional.of(centralTenantId));
-    when(tenantService.isCurrentTenantCentral()).thenReturn(true);
     when(executionService.executeSystemUserScoped(eq(centralTenantId), any(Callable.class)))
       .thenAnswer(inv -> ((Callable<?>) inv.getArgument(1)).call());
     when(searchInstancesClient.findInstances("id==" + instanceId, true))
@@ -286,7 +284,6 @@ class MediatedBatchRequestServiceTest {
 
     when(requestMediatedClient.getMediatedBatchRequestDetails(batchId, 5, 0)).thenReturn(batchDetails);
     when(tenantService.getCentralTenantId()).thenReturn(java.util.Optional.of(centralTenantId));
-    when(tenantService.isCurrentTenantCentral()).thenReturn(true);
     when(executionService.executeSystemUserScoped(eq(centralTenantId), any(Callable.class)))
       .thenAnswer(inv -> ((Callable<?>) inv.getArgument(1)).call());
     when(searchInstancesClient.findInstances("id==" + instanceId, true)).thenReturn(null);
@@ -322,7 +319,6 @@ class MediatedBatchRequestServiceTest {
     when(tenantService.isCurrentTenantSecure()).thenReturn(true);
     when(requestMediatedClient.getMediatedRequestsByQuery(anyString())).thenReturn(mediatedRequests);
     when(tenantService.getCentralTenantId()).thenReturn(java.util.Optional.of(centralTenantId));
-    when(tenantService.isCurrentTenantCentral()).thenReturn(true);
     when(executionService.executeSystemUserScoped(eq(centralTenantId), any(Callable.class)))
       .thenAnswer(inv -> ((Callable<?>) inv.getArgument(1)).call());
     when(searchInstancesClient.findInstances("id==" + instanceId, true)).thenReturn(searchInstances);
@@ -335,20 +331,28 @@ class MediatedBatchRequestServiceTest {
   }
 
   @Test
-  void resolveInstanceThrowsWhenCalledFromMemberTenantInEcsEnvironment() {
+  void resolveInstanceFetchesFromCentralTenantWhenCalledFromMemberTenantInEcsEnvironment() {
     var instanceId = UUID.randomUUID();
     var batchId = UUID.randomUUID();
     var centralTenantId = "consortium";
+    var title = "Interesting Times";
 
     var batchDetails = new BatchRequestDetailsResponse().mediatedBatchRequestDetails(List.of());
+    var searchInstances = new SearchInstances()
+      .instances(List.of(new SearchInstance().id(instanceId.toString()).title(title)));
 
     when(requestMediatedClient.getMediatedBatchRequestDetails(batchId, 5, 0)).thenReturn(batchDetails);
     when(tenantService.getCentralTenantId()).thenReturn(java.util.Optional.of(centralTenantId));
-    when(tenantService.isCurrentTenantCentral()).thenReturn(false);
-    when(tenantService.getCurrentTenantId()).thenReturn("member-tenant");
+    when(executionService.executeSystemUserScoped(eq(centralTenantId), any(Callable.class)))
+      .thenAnswer(inv -> ((Callable<?>) inv.getArgument(1)).call());
+    when(searchInstancesClient.findInstances("id==" + instanceId, true)).thenReturn(searchInstances);
 
-    org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class,
-      () -> service.retrieveMediatedBatchRequestDetails(instanceId, batchId, 0, 5));
+    var response = service.retrieveMediatedBatchRequestDetails(instanceId, batchId, 0, 5);
+
+    assertThat(response.getInstance(), is(notNullValue()));
+    assertThat(response.getInstance().getId(), is(instanceId.toString()));
+    assertThat(response.getInstance().getTitle(), is(title));
+    verify(executionService).executeSystemUserScoped(eq(centralTenantId), any(Callable.class));
   }
 
   @Test


### PR DESCRIPTION
## Purpose
Fix 500 error when mod-patron calls the batch details endpoint from a member/secure tenant in ECS environment. The IllegalStateException was thrown incorrectly — blocking any non-central tenant from using the endpoint. 

## Approach
Removed the isCurrentTenantCentral() guard from fetchInstanceFromCentralTenant. In ECS, executeSystemUserScoped(centralTenantId) always switches the request context to the central tenant regardless of who calls the endpoint — so the check was unnecessary and harmful. Added integration tests covering member and secure tenant scenarios to verify the fix.  

#### TODOS and Open Questions
- [x] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
[MCBFF-186](https://folio-org.atlassian.net/browse/MCBFF-186)