### PR TITLE
MCBFF-195:Hold and Transit slips printed in Central tenant contain UU…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 1.3.0-SNAPSHOT In progress
 * Resolve instance for batch details endpoint (MCBFF-186)
+* Populate staff slip material type and loan type with names instead of IDs (MCBFF-195)
 
 
 ## 1.2.0 2026-04-15

--- a/src/main/java/org/folio/circulationbff/service/impl/CheckInServiceImpl.java
+++ b/src/main/java/org/folio/circulationbff/service/impl/CheckInServiceImpl.java
@@ -13,6 +13,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.folio.circulationbff.client.CheckInClient;
 import org.folio.circulationbff.client.CirculationItemClient;
 import org.folio.circulationbff.client.HoldingsStorageClient;
+import org.folio.circulationbff.client.LoanTypeClient;
+import org.folio.circulationbff.client.MaterialTypeClient;
 import org.folio.circulationbff.client.RequestMediatedClient;
 import org.folio.circulationbff.domain.dto.CheckInRequest;
 import org.folio.circulationbff.domain.dto.CheckInResponse;
@@ -53,6 +55,8 @@ public class CheckInServiceImpl implements CheckInService {
   private final CirculationItemClient circulationItemClient;
   private final HoldingsStorageClient holdingsStorageClient;
   private final RequestMediatedClient requestMediatedClient;
+  private final MaterialTypeClient materialTypeClient;
+  private final LoanTypeClient loanTypeClient;
 
   private final SettingsService settingsService;
   private final TenantService tenantService;
@@ -309,8 +313,8 @@ public class CheckInServiceImpl implements CheckInService {
       .yearCaption(item.getYearCaption() != null
         ? String.join("; ", item.getYearCaption())
         : null)
-      .loanType(item.getPermanentLoanTypeId())
-      .materialType(item.getMaterialTypeId())
+      .loanType(fetchLoanTypeName(item.getPermanentLoanTypeId()))
+      .materialType(fetchMaterialTypeName(item.getMaterialTypeId()))
       .numberOfPieces(item.getNumberOfPieces())
       .descriptionOfPieces(item.getDescriptionOfPieces())
       .lastCheckedInDateTime(item.getLastCheckIn() != null
@@ -337,6 +341,24 @@ public class CheckInServiceImpl implements CheckInService {
 
     log.info("rebuildCheckInStaffSlipContext:: staff slips context for item {} " +
       "has been successfully built", item::getId);
+  }
+
+  private String fetchLoanTypeName(String loanTypeId) {
+    if (StringUtils.isBlank(loanTypeId)) {
+      return null;
+    }
+    log.info("fetchLoanTypeName:: loanTypeId={}", loanTypeId);
+    var loanType = loanTypeClient.findLoanType(loanTypeId);
+    return loanType == null ? null : loanType.getName();
+  }
+
+  private String fetchMaterialTypeName(String materialTypeId) {
+    if (StringUtils.isBlank(materialTypeId)) {
+      return null;
+    }
+    log.info("fetchMaterialTypeName:: materialTypeId={}", materialTypeId);
+    var materialType = materialTypeClient.findMaterialType(materialTypeId);
+    return materialType == null ? null : materialType.getName();
   }
 
   private void rebuildCheckInItem(CheckInResponse response, SearchInstance searchInstance,

--- a/src/test/java/org/folio/circulationbff/api/CheckInApiTest.java
+++ b/src/test/java/org/folio/circulationbff/api/CheckInApiTest.java
@@ -39,9 +39,11 @@ import org.folio.circulationbff.domain.dto.Institution;
 import org.folio.circulationbff.domain.dto.Item;
 import org.folio.circulationbff.domain.dto.Library;
 import org.folio.circulationbff.domain.dto.Loan;
+import org.folio.circulationbff.domain.dto.LoanType;
 import org.folio.circulationbff.domain.dto.LoanStatus;
 import org.folio.circulationbff.domain.dto.Loans;
 import org.folio.circulationbff.domain.dto.Location;
+import org.folio.circulationbff.domain.dto.MaterialType;
 import org.folio.circulationbff.domain.dto.SearchInstance;
 import org.folio.circulationbff.domain.dto.SearchInstances;
 import org.folio.circulationbff.domain.dto.SearchItem;
@@ -66,6 +68,8 @@ class CheckInApiTest extends BaseIT {
   private static final String REQUESTS_MEDIATED_CHECK_IN_URL = "/requests-mediated/loans/check-in-by-barcode";
   private static final String CIRCULATION_ITEM_URL = "/circulation-item/%s";
   private static final String HOLDING_STORAGE_URL = "/holdings-storage/holdings/%s";
+  private static final String LOAN_TYPE_URL = "/loan-types/%s";
+  private static final String MATERIAL_TYPE_URL = "/material-types/%s";
   private static final String LOAN_STORAGE_URL = "/loan-storage/loans";
   private static final String USERS_URL = "/users";
 
@@ -146,6 +150,10 @@ class CheckInApiTest extends BaseIT {
     var primaryServicePointName = "updated service point";
     var holdingRecordId = randomId();
     var callNumber = "CNTST";
+    var materialTypeId = randomId();
+    var materialTypeName = "Shared material";
+    var loanTypeId = randomId();
+    var loanTypeName = "loan";
     givenCirculationCheckInForInTransitItemSucceed(request, itemId, DCB_INSTANCE_ID);
     var checkinItem = new Item()
       .id(itemId)
@@ -153,6 +161,8 @@ class CheckInApiTest extends BaseIT {
       .inTransitDestinationServicePointId(primaryServicePointId.toString())
       .copyNumber("copyNumber")
       .effectiveLocationId(effectiveLocationId)
+      .materialTypeId(materialTypeId)
+      .permanentLoanTypeId(loanTypeId)
       .itemLevelCallNumber(callNumber);
     givenSearchInstanceReturnsItem(TENANT_ID_COLLEGE, checkinItem);
     givenCurrentTenantIsConsortium();
@@ -194,6 +204,12 @@ class CheckInApiTest extends BaseIT {
     wireMockServer.stubFor(WireMock.get(urlMatching("/location-units/libraries/" + libraryId))
       .withHeader(HEADER_TENANT, WireMock.equalTo(TENANT_ID_COLLEGE))
       .willReturn(jsonResponse(library, SC_OK)));
+    wireMockServer.stubFor(WireMock.get(urlMatching(format(MATERIAL_TYPE_URL, materialTypeId)))
+      .withHeader(HEADER_TENANT, WireMock.equalTo(TENANT_ID_COLLEGE))
+      .willReturn(jsonResponse(new MaterialType().id(materialTypeId).name(materialTypeName), SC_OK)));
+    wireMockServer.stubFor(WireMock.get(urlMatching(format(LOAN_TYPE_URL, loanTypeId)))
+      .withHeader(HEADER_TENANT, WireMock.equalTo(TENANT_ID_COLLEGE))
+      .willReturn(jsonResponse(new LoanType().id(loanTypeId).name(loanTypeName), SC_OK)));
 
     checkIn(request)
       .andExpect(status().isOk())
@@ -203,6 +219,8 @@ class CheckInApiTest extends BaseIT {
       .andExpect(jsonPath("$.staffSlipContext.item.effectiveLocationCampus", equalTo(campus.getName())))
       .andExpect(jsonPath("$.staffSlipContext.item.effectiveLocationLibrary", equalTo(library.getName())))
       .andExpect(jsonPath("$.staffSlipContext.item.effectiveLocationSpecific", equalTo(location.getName())))
+      .andExpect(jsonPath("$.staffSlipContext.item.materialType", equalTo(materialTypeName)))
+      .andExpect(jsonPath("$.staffSlipContext.item.loanType", equalTo(loanTypeName)))
       .andExpect(jsonPath("$.staffSlipContext.item.callNumber", equalTo(callNumber)))
       .andExpect(jsonPath("$.item.inTransitDestinationServicePointId", equalTo(primaryServicePointId.toString())))
       .andExpect(jsonPath("$.item.inTransitDestinationServicePoint.id", equalTo(primaryServicePointId.toString())))

--- a/src/test/java/org/folio/circulationbff/service/CheckInServiceTest.java
+++ b/src/test/java/org/folio/circulationbff/service/CheckInServiceTest.java
@@ -17,6 +17,8 @@ import java.util.UUID;
 import org.folio.circulationbff.client.CheckInClient;
 import org.folio.circulationbff.client.CirculationItemClient;
 import org.folio.circulationbff.client.HoldingsStorageClient;
+import org.folio.circulationbff.client.LoanTypeClient;
+import org.folio.circulationbff.client.MaterialTypeClient;
 import org.folio.circulationbff.client.RequestMediatedClient;
 import org.folio.circulationbff.domain.dto.CheckInRequest;
 import org.folio.circulationbff.domain.dto.CheckInResponse;
@@ -52,6 +54,10 @@ class CheckInServiceTest {
   private HoldingsStorageClient holdingsStorageClient;
   @Mock
   private RequestMediatedClient requestMediatedClient;
+  @Mock
+  private MaterialTypeClient materialTypeClient;
+  @Mock
+  private LoanTypeClient loanTypeClient;
   @Mock
   private SettingsService settingsService;
   @Mock


### PR DESCRIPTION
Fixing - Hold and Transit slips printed in Central tenant contain UUIDs instead of item "Material type" and "Loan type"